### PR TITLE
🏗️ Fix Makefile rule name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ GREEN 			= /bin/echo -e "\x1b[32m $1\x1b[0m"
 YELLOW 			= /bin/echo -e "\x1b[33m $1\x1b[0m"
 
 #Rules
-all: core games graphics
+all: core games graphicals
 
 #-----------------Games Rules--------------------
 

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ $(NAME) : $(OBJ_CORE)
 
 #-----------------Graphics Rules------------------
 
-graphics: $(NAME_NCURSES) $(NAME_SFML) $(NAME_SDL)
+graphicals: $(NAME_NCURSES) $(NAME_SFML) $(NAME_SDL)
 
 %.o: 	%.cpp
 	@$(CC) $(INC) $(CXXFLAGS) -fPIC -c -o $@ $< && \


### PR DESCRIPTION
# :building_construction:  Fix rule naming

### ⚙️ Description
Fix rule naming in the makefile for the graphics lib

### Related Issues 
- #60 